### PR TITLE
Add test for TypingCache.removeUser

### DIFF
--- a/src/github.com/matrix-org/dendrite/typingserver/cache/cache.go
+++ b/src/github.com/matrix-org/dendrite/typingserver/cache/cache.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-var defaultTypingTimeout = 10 * time.Second
+const defaultTypingTimeout = 10 * time.Second
 
 // userSet is a map of user IDs to a timer, timer fires at expiry.
 type userSet map[string]*time.Timer
@@ -40,8 +40,8 @@ func (t *TypingCache) GetTypingUsers(roomID string) (users []string) {
 	t.RUnlock()
 	if ok {
 		users = make([]string, 0, len(usersMap))
-		for key := range usersMap {
-			users = append(users, key)
+		for userID := range usersMap {
+			users = append(users, userID)
 		}
 	}
 

--- a/src/github.com/matrix-org/dendrite/typingserver/cache/cache_test.go
+++ b/src/github.com/matrix-org/dendrite/typingserver/cache/cache_test.go
@@ -13,6 +13,7 @@
 package cache
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -31,6 +32,10 @@ func TestTypingCache(t *testing.T) {
 
 	t.Run("GetTypingUsers", func(t *testing.T) {
 		testGetTypingUsers(t, tCache)
+	})
+
+	t.Run("removeUser", func(t *testing.T) {
+		testRemoveUser(t, tCache)
 	})
 }
 
@@ -69,4 +74,27 @@ func testGetTypingUsers(t *testing.T, tCache *TypingCache) {
 			t.Errorf("TypingCache.GetTypingUsers(%s) = %v, want %v", tt.roomID, gotUsers, tt.wantUsers)
 		}
 	}
+}
+
+func testRemoveUser(t *testing.T, tCache *TypingCache) {
+	tests := []struct {
+		roomID  string
+		userIDs []string
+	}{
+		{"room3", []string{"user1"}},
+		{"room4", []string{"user1", "user2", "user3"}},
+	}
+	for _, tt := range tests {
+		for _, userID := range tt.userIDs {
+			tCache.AddTypingUser(userID, tt.roomID, nil)
+		}
+		i := rand.Intn(len(tt.userIDs))
+		tCache.removeUser(tt.userIDs[i], tt.roomID)
+		expLeftUsers := append(tt.userIDs[:i], tt.userIDs[i+1:]...)
+
+		if leftUsers := tCache.GetTypingUsers(tt.roomID); !test.UnsortedStringSliceEqual(leftUsers, expLeftUsers) {
+			t.Errorf("Response after removal is unexpected %s/%s", leftUsers, expLeftUsers)
+		}
+	}
+
 }


### PR DESCRIPTION
Feel free to merge it if you like.

BTW: You will need a `removeUser` method as clients can send a `typing = false` request in which case you will want to remove it unrelated to a probably existing timeout.
You can have a look at the [Matrix-Spec](https://matrix.org/speculator/spec/HEAD/client_server/unstable.html#put-matrix-client-r0-rooms-roomid-typing-userid)

Signed-Off-By: Matthias Kesler <krombel@krombel.de>